### PR TITLE
RF: Provide an "interface" to perform ID mapping to an external DB

### DIFF
--- a/nidmresults/objects/generic.py
+++ b/nidmresults/objects/generic.py
@@ -37,6 +37,25 @@ class NIDMObject(object):
                 oid = NIIRI.qname(Identifier(oid))
             self.id = oid
 
+    # the next three methods build a .file property
+    # with a dedicated function call on "set" that can
+    # be used to implement external ID mappings
+    # e.g. DataLad can replace '_map_fileid()' to provides
+    # its internal file IDs based on the filename associated
+    # with a NIDMFile object
+    @property
+    def file(self):
+        return getattr(self, '_file', None)
+
+    @file.setter
+    def file(self, fileobj):
+        if isinstance(fileobj, NIDMFile):
+            self._map_fileid(fileobj)
+        self._file = fileobj
+
+    def _map_fileid(self, fileobj):
+        pass
+
     def __str__(self):
         value = ""
         if hasattr(self, 'value'):


### PR DESCRIPTION
With this change in place, DataLad can replace the mapping function with something like this:

```python
def _map_ids(parentobj, fileobj):
    id_ = idmap.get(fileobj.path, fileobj.id)
    fileobj.id = id_
    parentobj.id = id_
```

where `idmap` is a DataLad-provided dictionary that maps absolute file paths to DataLad's file IDs. The `id` of both the file, and the parent objects (e.g. a Contrast) are adjusted. This happens on every `self.file=` set-call, that typically happens in the constructor of `NIDMObject`s

Technically this is all nice, but it doesn't work, because DataLad's IDs are rejected in `site-packages/prov/model.py` line 1608, by `self.valid_qualified_name(identifier)`, where `identifier` would look like `MD5E-s612--5fa06e4a914134058849a67e671e0057.png`, for example. `valid_qualified_name()` returns `None` for this. I do not yet understand why, or what could be done about it. Feedback or suggestions on this would be great!

FTR, here is the full code of DataLad calling nidmresults-fsl:

```python
    def _map_ids(parentobj, fileobj):
        id_ = idmap.get(fileobj.path, fileobj.id)
        fileobj.id = id_
        parentobj.id = id_

    from mock import patch
    from nidmfsl.fsl_exporter.fsl_exporter import FSLtoNIDMExporter
    with make_tempfile(mkdir=True) as tmpdir, \
            patch(
                'nidmresults.objects.generic.NIDMObject._map_fileid',
                _map_ids):
        exporter = FSLtoNIDMExporter(
            out_dirname=tmpdir,
            zipped=False,
            feat_dir=text_type(feat_dir),
            # this is all fake, we cannot know it, but NIDM FSL wants it
            # TODO try fishing it out from the result again
            groups=[['control', 1]])
        exporter.parse()
        outdir = exporter.export()
        md = jsonload(text_type(Path(outdir) / 'nidm.json'))
 ```